### PR TITLE
Update instalation instructions for 0.2.0 📖

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ You can install the `BaggageContext` library through the Swift Package Manager. 
 ```swift
 dependencies: [
   .package(
-    name: "swift-baggage-context", 
-    url: "https://github.com/slashmo/gsoc-swift-baggage-context.git", 
-    from: "0.1.0"
+    name: "swift-baggage-context",
+    url: "https://github.com/slashmo/gsoc-swift-baggage-context.git",
+    from: "0.2.0"
   )
 ]
 ```


### PR DESCRIPTION
In order for us to be able to use the recently merged #9, I'd like to release a new tag. @ktoso Are you happy with `0.2.0`? I didn't feel `0.1.1` was enough as `forEach` instead of `baggageItems` is source-breaking. Everything else I checked is additive.