### PR TITLE
Require Baggage library in BaggageLogging target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,8 @@ let package = Package(
         .target(
             name: "BaggageLogging",
             dependencies: [
-                .product(name: "Logging", package: "swift-log")
+                "Baggage",
+                .product(name: "Logging", package: "swift-log"),
             ]
         ),
 


### PR DESCRIPTION
Attempt to fix the CI: https://github.com/slashmo/gsoc-swift-baggage-context/actions/runs/211812540

Tests somehow work on a branch but not when merged into `main` 🤔