### PR TITLE
Semantically helpfully named empty baggage factory functions #26

### DIFF
--- a/Sources/BaggageBenchmarkTools/ArgParser.swift
+++ b/Sources/BaggageBenchmarkTools/ArgParser.swift
@@ -219,7 +219,7 @@ class ArgumentParser<U> {
     ) {
         self.arguments.append(
             Argument(name: name, help: help)
-                { try self.parseArgument(name, property, defaultValue, parser) }
+            { try self.parseArgument(name, property, defaultValue, parser) }
         )
     }
 

--- a/Sources/BaggageBenchmarks/BaggagePassingBenchmarks.swift
+++ b/Sources/BaggageBenchmarks/BaggagePassingBenchmarks.swift
@@ -21,7 +21,7 @@ public let BaggagePassingBenchmarks: [BenchmarkInfo] = [
     BenchmarkInfo(
         name: "BaggagePassingBenchmarks.pass_async_empty_100_000         ",
         runFunction: { _ in
-            let context = BaggageContext.empty
+            let context = BaggageContext.background
             pass_async(context: context, times: 100_000)
         },
         tags: [],
@@ -31,7 +31,7 @@ public let BaggagePassingBenchmarks: [BenchmarkInfo] = [
     BenchmarkInfo(
         name: "BaggagePassingBenchmarks.pass_async_smol_100_000          ",
         runFunction: { _ in
-            var context = BaggageContext.empty
+            var context = BaggageContext.background
             context.k1 = "one"
             context.k2 = "two"
             context.k3 = "three"
@@ -45,7 +45,7 @@ public let BaggagePassingBenchmarks: [BenchmarkInfo] = [
     BenchmarkInfo(
         name: "BaggagePassingBenchmarks.pass_async_small_nonconst_100_000",
         runFunction: { _ in
-            var context = BaggageContext.empty
+            var context = BaggageContext.background
             context.k1 = "\(Int.random(in: 1 ... Int.max))"
             context.k2 = "\(Int.random(in: 1 ... Int.max))"
             context.k3 = "\(Int.random(in: 1 ... Int.max))"
@@ -65,7 +65,7 @@ public let BaggagePassingBenchmarks: [BenchmarkInfo] = [
     BenchmarkInfo(
         name: "BaggagePassingBenchmarks.pass_mut_async_small_100_000     ",
         runFunction: { _ in
-            var context = BaggageContext.empty
+            var context = BaggageContext.background
             context.k1 = "\(Int.random(in: 1 ... Int.max))"
             context.k2 = "\(Int.random(in: 1 ... Int.max))"
             context.k3 = "\(Int.random(in: 1 ... Int.max))"

--- a/Sources/BaggageBenchmarks/BaggagePassingBenchmarks.swift
+++ b/Sources/BaggageBenchmarks/BaggagePassingBenchmarks.swift
@@ -21,7 +21,7 @@ public let BaggagePassingBenchmarks: [BenchmarkInfo] = [
     BenchmarkInfo(
         name: "BaggagePassingBenchmarks.pass_async_empty_100_000         ",
         runFunction: { _ in
-            let context = BaggageContext()
+            let context = BaggageContext.empty
             pass_async(context: context, times: 100_000)
         },
         tags: [],
@@ -31,7 +31,7 @@ public let BaggagePassingBenchmarks: [BenchmarkInfo] = [
     BenchmarkInfo(
         name: "BaggagePassingBenchmarks.pass_async_smol_100_000          ",
         runFunction: { _ in
-            var context = BaggageContext()
+            var context = BaggageContext.empty
             context.k1 = "one"
             context.k2 = "two"
             context.k3 = "three"
@@ -45,7 +45,7 @@ public let BaggagePassingBenchmarks: [BenchmarkInfo] = [
     BenchmarkInfo(
         name: "BaggagePassingBenchmarks.pass_async_small_nonconst_100_000",
         runFunction: { _ in
-            var context = BaggageContext()
+            var context = BaggageContext.empty
             context.k1 = "\(Int.random(in: 1 ... Int.max))"
             context.k2 = "\(Int.random(in: 1 ... Int.max))"
             context.k3 = "\(Int.random(in: 1 ... Int.max))"
@@ -65,7 +65,7 @@ public let BaggagePassingBenchmarks: [BenchmarkInfo] = [
     BenchmarkInfo(
         name: "BaggagePassingBenchmarks.pass_mut_async_small_100_000     ",
         runFunction: { _ in
-            var context = BaggageContext()
+            var context = BaggageContext.empty
             context.k1 = "\(Int.random(in: 1 ... Int.max))"
             context.k2 = "\(Int.random(in: 1 ... Int.max))"
             context.k3 = "\(Int.random(in: 1 ... Int.max))"

--- a/Tests/BaggageLoggingTests/LoggingBaggageContextCarrierTests.swift
+++ b/Tests/BaggageLoggingTests/LoggingBaggageContextCarrierTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 final class LoggingBaggageContextCarrierTests: XCTestCase {
     func test_ContextWithLogger_dumpBaggage() throws {
-        let baggage = BaggageContext.empty
+        let baggage = BaggageContext.background
         let logger = Logger(label: "TheLogger")
 
         var context: LoggingBaggageContextCarrier = ExampleFrameworkContext(context: baggage, logger: logger)
@@ -43,7 +43,7 @@ final class LoggingBaggageContextCarrierTests: XCTestCase {
     }
 
     func test_ContextWithLogger_log_withBaggage() throws {
-        let baggage = BaggageContext.empty
+        let baggage = BaggageContext.background
         let logging = TestLogging()
         let logger = Logger(label: "TheLogger", factory: { label in logging.make(label: label) })
 
@@ -66,7 +66,7 @@ final class LoggingBaggageContextCarrierTests: XCTestCase {
     }
 
     func test_ContextWithLogger_log_prefersBaggageContextOverExistingLoggerMetadata() {
-        let baggage = BaggageContext.empty
+        let baggage = BaggageContext.background
         let logging = TestLogging()
         var logger = Logger(label: "TheLogger", factory: { label in logging.make(label: label) })
         logger[metadataKey: "secondIDExplicitlyNamed"] = "set on logger"
@@ -103,7 +103,7 @@ struct CoolFrameworkContext: LoggingBaggageContextCarrier {
         return self._logger.with(context: self.baggage)
     }
 
-    var baggage: BaggageContext = .empty
+    var baggage: BaggageContext = .background
 
     // framework context defines other values as well
     let frameworkField: String = ""

--- a/Tests/BaggageLoggingTests/LoggingBaggageContextCarrierTests.swift
+++ b/Tests/BaggageLoggingTests/LoggingBaggageContextCarrierTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 final class LoggingBaggageContextCarrierTests: XCTestCase {
     func test_ContextWithLogger_dumpBaggage() throws {
-        let baggage = BaggageContext()
+        let baggage = BaggageContext.empty
         let logger = Logger(label: "TheLogger")
 
         var context: LoggingBaggageContextCarrier = ExampleFrameworkContext(context: baggage, logger: logger)
@@ -43,7 +43,7 @@ final class LoggingBaggageContextCarrierTests: XCTestCase {
     }
 
     func test_ContextWithLogger_log_withBaggage() throws {
-        let baggage = BaggageContext()
+        let baggage = BaggageContext.empty
         let logging = TestLogging()
         let logger = Logger(label: "TheLogger", factory: { label in logging.make(label: label) })
 
@@ -66,7 +66,7 @@ final class LoggingBaggageContextCarrierTests: XCTestCase {
     }
 
     func test_ContextWithLogger_log_prefersBaggageContextOverExistingLoggerMetadata() {
-        let baggage = BaggageContext()
+        let baggage = BaggageContext.empty
         let logging = TestLogging()
         var logger = Logger(label: "TheLogger", factory: { label in logging.make(label: label) })
         logger[metadataKey: "secondIDExplicitlyNamed"] = "set on logger"
@@ -103,7 +103,7 @@ struct CoolFrameworkContext: LoggingBaggageContextCarrier {
         return self._logger.with(context: self.baggage)
     }
 
-    var baggage: BaggageContext = .init()
+    var baggage: BaggageContext = .empty
 
     // framework context defines other values as well
     let frameworkField: String = ""

--- a/Tests/BaggageLoggingTests/TestLogger.swift
+++ b/Tests/BaggageLoggingTests/TestLogger.swift
@@ -194,8 +194,7 @@ extension History {
                      metadata: Logger.Metadata? = nil,
                      source: String? = nil,
                      file: StaticString = #file,
-                     line: UInt = #line)
-    {
+                     line: UInt = #line) {
         let source = source ?? Logger.currentModule(filePath: "\(file)")
         let entry = self.find(level: level, message: message, metadata: metadata, source: source)
         XCTAssertNotNil(
@@ -215,8 +214,7 @@ extension History {
                         metadata: Logger.Metadata? = nil,
                         source: String? = nil,
                         file: StaticString = #file,
-                        line: UInt = #line)
-    {
+                        line: UInt = #line) {
         let source = source ?? Logger.currentModule(filePath: "\(file)")
         let entry = self.find(level: level, message: message, metadata: metadata, source: source)
         XCTAssertNil(

--- a/Tests/BaggageTests/BaggageContextTests+XCTest.swift
+++ b/Tests/BaggageTests/BaggageContextTests+XCTest.swift
@@ -30,6 +30,8 @@ extension BaggageContextTests {
                 ("testEmptyBaggageDescription", testEmptyBaggageDescription),
                 ("testSingleKeyBaggageDescription", testSingleKeyBaggageDescription),
                 ("testMultiKeysBaggageDescription", testMultiKeysBaggageDescription),
+                ("test_todo_context", test_todo_context),
+                ("test_todo_empty", test_todo_empty),
            ]
    }
 }

--- a/Tests/BaggageTests/BaggageContextTests.swift
+++ b/Tests/BaggageTests/BaggageContextTests.swift
@@ -18,7 +18,7 @@ final class BaggageContextTests: XCTestCase {
     func testSubscriptAccess() {
         let testID = 42
 
-        var baggage = BaggageContext()
+        var baggage = BaggageContext.empty
         XCTAssertNil(baggage[TestIDKey.self])
 
         baggage[TestIDKey.self] = testID
@@ -31,7 +31,7 @@ final class BaggageContextTests: XCTestCase {
     func testRecommendedConvenienceExtension() {
         let testID = 42
 
-        var baggage = BaggageContext()
+        var baggage = BaggageContext.empty
         XCTAssertNil(baggage.testID)
 
         baggage.testID = testID
@@ -42,18 +42,18 @@ final class BaggageContextTests: XCTestCase {
     }
 
     func testEmptyBaggageDescription() {
-        XCTAssertEqual(String(describing: BaggageContext()), "BaggageContext(keys: [])")
+        XCTAssertEqual(String(describing: BaggageContext.empty), "BaggageContext(keys: [])")
     }
 
     func testSingleKeyBaggageDescription() {
-        var baggage = BaggageContext()
+        var baggage = BaggageContext.empty
         baggage.testID = 42
 
         XCTAssertEqual(String(describing: baggage), #"BaggageContext(keys: ["TestIDKey"])"#)
     }
 
     func testMultiKeysBaggageDescription() {
-        var baggage = BaggageContext()
+        var baggage = BaggageContext.empty
         baggage.testID = 42
         baggage[SecondTestIDKey.self] = "test"
 
@@ -62,6 +62,33 @@ final class BaggageContextTests: XCTestCase {
         // use contains instead of `XCTAssertEqual` because the order is non-predictable (Dictionary)
         XCTAssert(description.contains("TestIDKey"))
         XCTAssert(description.contains("ExplicitKeyName"))
+    }
+
+    // ==== ------------------------------------------------------------------------------------------------------------
+    // MARK: Factories
+
+    func test_todo_context() {
+        // the to-do context can be used to record intentions for why a context could not be passed through
+        let context = BaggageContext.TODO("#1245 Some other library should be adjusted to pass us context")
+        _ = context // avoid "not used" warning
+
+        // TODO: Can't work with protocols; re-consider the entire carrier approach... Context being a Baggage + Logger, and a specific type.
+//        func take(context: BaggageContextProtocol) {
+//            _ = context // ignore
+//        }
+//        take(context: .TODO("pass from request instead"))
+    }
+
+    func test_todo_empty() {
+        let context = BaggageContext.empty
+        _ = context // avoid "not used" warning
+
+        // TODO: Can't work with protocols; re-consider the entire carrier approach... Context being a Baggage + Logger, and a specific type.
+        // static member 'empty' cannot be used on protocol metatype 'BaggageContextProtocol.Protocol'
+//        func take(context: BaggageContextProtocol) {
+//            _ = context // ignore
+//        }
+//        take(context: .empty)
     }
 }
 

--- a/Tests/BaggageTests/BaggageContextTests.swift
+++ b/Tests/BaggageTests/BaggageContextTests.swift
@@ -18,7 +18,7 @@ final class BaggageContextTests: XCTestCase {
     func testSubscriptAccess() {
         let testID = 42
 
-        var baggage = BaggageContext.empty
+        var baggage = BaggageContext.background
         XCTAssertNil(baggage[TestIDKey.self])
 
         baggage[TestIDKey.self] = testID
@@ -31,7 +31,7 @@ final class BaggageContextTests: XCTestCase {
     func testRecommendedConvenienceExtension() {
         let testID = 42
 
-        var baggage = BaggageContext.empty
+        var baggage = BaggageContext.background
         XCTAssertNil(baggage.testID)
 
         baggage.testID = testID
@@ -42,18 +42,18 @@ final class BaggageContextTests: XCTestCase {
     }
 
     func testEmptyBaggageDescription() {
-        XCTAssertEqual(String(describing: BaggageContext.empty), "BaggageContext(keys: [])")
+        XCTAssertEqual(String(describing: BaggageContext.background), "BaggageContext(keys: [])")
     }
 
     func testSingleKeyBaggageDescription() {
-        var baggage = BaggageContext.empty
+        var baggage = BaggageContext.background
         baggage.testID = 42
 
         XCTAssertEqual(String(describing: baggage), #"BaggageContext(keys: ["TestIDKey"])"#)
     }
 
     func testMultiKeysBaggageDescription() {
-        var baggage = BaggageContext.empty
+        var baggage = BaggageContext.background
         baggage.testID = 42
         baggage[SecondTestIDKey.self] = "test"
 
@@ -80,7 +80,7 @@ final class BaggageContextTests: XCTestCase {
     }
 
     func test_todo_empty() {
-        let context = BaggageContext.empty
+        let context = BaggageContext.background
         _ = context // avoid "not used" warning
 
         // TODO: Can't work with protocols; re-consider the entire carrier approach... Context being a Baggage + Logger, and a specific type.
@@ -88,7 +88,7 @@ final class BaggageContextTests: XCTestCase {
 //        func take(context: BaggageContextProtocol) {
 //            _ = context // ignore
 //        }
-//        take(context: .empty)
+//        take(context: .background)
     }
 }
 


### PR DESCRIPTION
Resolves #26 - Semantically helpfully named empty baggage factory functions 

I went with:

- `.empty` and good docs when it should be used
- `TODO` inspired by https://golang.org/pkg/context/ which is quite useful I believe, and good for future linters and tooling potential
- making init private