### PR TITLE
Missed one rename from Final API PR

### DIFF
--- a/Sources/BaggageContext/BaggageContext.swift
+++ b/Sources/BaggageContext/BaggageContext.swift
@@ -17,7 +17,7 @@ import Logging
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Context Protocol
 
-/// The `ContextProtocol` MAY be adopted by specific "framework contexts" such as e.g. `CoolFramework.Context` in
+/// The `BaggageContext` MAY be adopted by specific "framework contexts" such as e.g. `CoolFramework.Context` in
 /// order to allow users to pass such context directly to libraries accepting any context.
 ///
 /// This allows frameworks and library authors to offer APIs which compose more easily.
@@ -29,9 +29,9 @@ import Logging
 /// and also for their user's sanity, as a reference semantics context type can be very confusing to use when shared
 /// between multiple threads, as often is the case in server side environments.
 ///
-/// It is STRONGLY encouraged to use the `DefaultContext` as inspiration for a correct implementation of a `Context`,
+/// It is STRONGLY encouraged to use the `DefaultContext` as inspiration for a correct implementation of a `BaggageContext`,
 /// as the relationship between `Logger` and `Baggage` can be tricky to wrap your head around at first.
-public protocol Context {
+public protocol BaggageContext {
     /// Get the `Baggage` container.
     ///
     /// ### Implementation notes
@@ -91,7 +91,7 @@ public protocol Context {
     var logger: Logger { get set }
 }
 
-/// A default `Context` type.
+/// A default `BaggageContext` type.
 ///
 /// It is a carrier of contextual `Baggage` and related `Logger`, allowing to log and trace throughout a system.
 ///
@@ -106,12 +106,12 @@ public protocol Context {
 ///
 /// ### Accepting context types in APIs
 ///
-/// It is preferred to accept values of `ContextProtocol` in library APIs, as this yields a more flexible API shape,
+/// It is preferred to accept values of `BaggageContext` in library APIs, as this yields a more flexible API shape,
 /// to which other libraries/frameworks may pass their specific context objects.
 ///
 /// - SeeAlso: `Baggage` from the Baggage module.
 /// - SeeAlso: `Logger` from the SwiftLog package.
-public struct DefaultContext: Context {
+public struct DefaultContext: BaggageContext {
     /// The `Baggage` carried with this context.
     /// It's values will automatically be made available to the `logger` as metadata when logging.
     ///
@@ -155,7 +155,7 @@ public struct DefaultContext: Context {
         self._logger.updateMetadata(previous: .topLevel, latest: baggage)
     }
 
-    public init<C>(context: C) where C: Context {
+    public init<Context>(context: Context) where Context: BaggageContext {
         self.baggage = context.baggage
         self._logger = context.logger
         self._logger.updateMetadata(previous: .topLevel, latest: self.baggage)

--- a/Sources/BaggageContextBenchmarkTools/ArgParser.swift
+++ b/Sources/BaggageContextBenchmarkTools/ArgParser.swift
@@ -219,7 +219,7 @@ class ArgumentParser<U> {
     ) {
         self.arguments.append(
             Argument(name: name, help: help)
-                { try self.parseArgument(name, property, defaultValue, parser) }
+            { try self.parseArgument(name, property, defaultValue, parser) }
         )
     }
 

--- a/Sources/BaggageContextBenchmarks/BaggageLoggingBenchmarks.swift
+++ b/Sources/BaggageContextBenchmarks/BaggageLoggingBenchmarks.swift
@@ -284,7 +284,7 @@ func log_loggerWithBaggage(logger: Logger, baggage: Baggage, iters remaining: In
 }
 
 @inline(never)
-func log_throughContext(context: Context, iters remaining: Int) {
+func log_throughContext(context: BaggageContext, iters remaining: Int) {
     for _ in 0 ..< remaining {
         context.logger.warning(message)
     }
@@ -298,14 +298,14 @@ func log_loggerWithBaggage_trace(logger: Logger, baggage: Baggage, iters remaini
 }
 
 @inline(never)
-func log_throughContext_trace(context: Context, iters remaining: Int) {
+func log_throughContext_trace(context: BaggageContext, iters remaining: Int) {
     for _ in 0 ..< remaining {
         context.logger.trace(message)
     }
 }
 
 @inline(never)
-func log_materializeOnce_trace(context: Context, iters remaining: Int) {
+func log_materializeOnce_trace(context: BaggageContext, iters remaining: Int) {
     var logger = context.logger
     context.baggage.forEach { key, value in
         logger[metadataKey: key.name] = "\(value)"
@@ -317,7 +317,7 @@ func log_materializeOnce_trace(context: Context, iters remaining: Int) {
 }
 
 @inline(never)
-func log_materializeOnce(context: Context, iters remaining: Int) {
+func log_materializeOnce(context: BaggageContext, iters remaining: Int) {
     var logger = context.logger
     context.baggage.forEach { key, value in
         logger[metadataKey: key.name] = "\(value)"

--- a/Tests/BaggageContextTests/BaggageContextTests.swift
+++ b/Tests/BaggageContextTests/BaggageContextTests.swift
@@ -24,7 +24,7 @@ final class BaggageContextTests: XCTestCase {
         baggage.testID = 42
         let context = ExampleFrameworkContext(context: baggage, logger: logger)
 
-        func frameworkFunctionDumpsBaggage(param: String, context: Context) -> String {
+        func frameworkFunctionDumpsBaggage(param: String, context: BaggageContext) -> String {
             var s = ""
             context.baggage.forEach { key, item in
                 s += "\(key.name): \(item)\n"
@@ -123,7 +123,7 @@ final class BaggageContextTests: XCTestCase {
     }
 }
 
-struct ExampleFrameworkContext: BaggageContext.Context {
+struct ExampleFrameworkContext: BaggageContext {
     var baggage: Baggage {
         willSet {
             self._logger.updateMetadata(previous: self.baggage, latest: newValue)
@@ -148,7 +148,7 @@ struct ExampleFrameworkContext: BaggageContext.Context {
     }
 }
 
-struct CoolFrameworkContext: BaggageContext.Context {
+struct CoolFrameworkContext: BaggageContext {
     var baggage: Baggage {
         willSet {
             self.logger.updateMetadata(previous: self.baggage, latest: newValue)

--- a/Tests/BaggageContextTests/FrameworkContextTests.swift
+++ b/Tests/BaggageContextTests/FrameworkContextTests.swift
@@ -43,7 +43,7 @@ final class FrameworkBaggageContextTests: XCTestCase {
     }
 }
 
-private struct TestFrameworkContext: Context {
+private struct TestFrameworkContext: BaggageContext {
     var baggage = Baggage.topLevel
 
     private var _logger = Logger(label: "test")

--- a/Tests/BaggageContextTests/TestLogger.swift
+++ b/Tests/BaggageContextTests/TestLogger.swift
@@ -190,8 +190,7 @@ extension History {
                      metadata: Logger.Metadata? = nil,
                      source: String? = nil,
                      file: StaticString = #file,
-                     line: UInt = #line)
-    {
+                     line: UInt = #line) {
         let source = source ?? Logger.currentModule(filePath: "\(file)")
         let entry = self.find(level: level, message: message, metadata: metadata, source: source)
         XCTAssertNotNil(
@@ -211,8 +210,7 @@ extension History {
                         metadata: Logger.Metadata? = nil,
                         source: String? = nil,
                         file: StaticString = #file,
-                        line: UInt = #line)
-    {
+                        line: UInt = #line) {
         let source = source ?? Logger.currentModule(filePath: "\(file)")
         let entry = self.find(level: level, message: message, metadata: metadata, source: source)
         XCTAssertNil(


### PR DESCRIPTION
So we actually agreed on the type name in discussions but forgot to reflect this agreement in the PR -- https://github.com/slashmo/gsoc-swift-baggage-context/pull/34

This should be the 0.5.0 @slashmo -- would you be ok to remove the tag (noone depended on it so far and this is a WIP repo anyway) and tag this after merging?

This causes the "module is same as the type" issue, but I'm working on figuring out an answer to that.